### PR TITLE
dpt is not a callback function

### DIFF
--- a/knx.js
+++ b/knx.js
@@ -213,7 +213,7 @@ module.exports = function (RED) {
 
                     try {
                         node.log("sendAPDU: " + util.inspect(value));
-                        connection.Action(dstgad.toString(), value, dpt);
+                        connection.Action(dstgad.toString(), value, null);
                         callback && callback();
                     }
                     catch (err) {


### PR DESCRIPTION
The Action function/method expects a function as third argument and not a regular value.
As dpt contains a value this will fail further in the line and crashes node-red.
