### PR TITLE
support for DPT 3

### DIFF
--- a/knx.html
+++ b/knx.html
@@ -78,10 +78,10 @@
     	<p> - 'write': (<b>default</b>) to write a value to the bus. Can be omitted.</p>
     	<br/>
     	<b>msg.payload</b> must be a JavaScript object or a string in JSON format
-    	<p> - dstgad: the destination <b>group</b> address (eg."1/2/3")</p>
-    	<p> - value: the actual value to send (eg."1")</p>
-    	<p> - dpt: the datapoint type (eg."1")</p>
-	for example: {"dstgad":"1/2/3", "value":"1", "dpt":"1"}
+    	<p> - 'dstgad': the destination <b>group</b> address (eg."1/2/3")</p>
+    	<p> - 'value': the actual value to send (eg."1"), for datapoint 3 this must be an object with attribute c = a boolean for an up increment, and attribute amount = value <=7 to increment by.</p>
+    	<p> - 'dpt': the datapoint type (eg."1")</p>
+	for example: {"dstgad":"1/2/3", "value":"1", "dpt":"1"} or {"dstgad":"3/2/2", "value":{"c":"true","amount":"4"},"dpt":"3"}
     </p>
 
 

--- a/knx.html
+++ b/knx.html
@@ -74,7 +74,7 @@
     <p>Use this to <b>send</b> KNX telegrams to a KNX/EIB network.<br/>
     	<b>msg.topic</b> can be:
     	<p> - 'read': to send a read request to the bus</p>
-    	<p> - respond': to send a response to another read request to the bus</p>
+    	<p> - 'respond': to send a response to another read request to the bus</p>
     	<p> - 'write': (<b>default</b>) to write a value to the bus. Can be omitted.</p>
     	<br/>
     	<b>msg.payload</b> must be a JavaScript object or a string in JSON format
@@ -89,7 +89,7 @@
 
 <script type="text/x-red" data-help-name="knx-in">
     <p>Use this to <b>inject</b> flows from KNX telegrams on the bus<br/>
-   	<b>msg.topic</b> will be: 
+   	<b>msg.topic</b> will be:
     	<p> - 'read': when a read request arrives on the bus</p>
     	<p> - 'respond': when another KNX device responds to a read request on the bus</p>
     	<p> - 'write': when somebody writes a value to a KNX group address.</p>

--- a/knx.js
+++ b/knx.js
@@ -182,16 +182,23 @@ module.exports = function (RED) {
                     value = (value.toString() === 'true' || value.toString() === '1')
                     break;
                 case '3': // Dimmer, control bit + 3 bit value
-                    if (typeof(value.c)==='undefined') {
-                      throw 'Value up/down control missing';
-                    } else if (value.amount <= 7) {
-                      value = ((value.c.toString() === 'true' || value.c.toString() === '1') << 3) |
-                        parseInt(value.amount) & 7;
+                    if (typeof(value.c) !== 'undefined' && value.c !== null &&
+                    typeof(value.amount) !== 'undefined' && value.amount !== null) {
+                      if (value.amount <= 7) {
+                        value = ((value.c.toString() === 'true' || value.c.toString() === '1') << 3) |
+                          parseInt(value.amount) & 7;
+                        buf = new Buffer(1);
+                        buf[0] = value & 15;
+                        value = buf;
+                      } else {
+                        throw 'Value step amount too big for DPT 3';
+                      }
+                    } else if (!isNaN(parseInt(value))) {
                       buf = new Buffer(1);
-                      buf[0] = value & 15;
+                      buf[0] = parseInt(value) & 15;
                       value = buf;
-                    } else {
-                      throw 'Value step amount too big for DPT 3';
+                    } else if (!Buffer.isBuffer(value)) {
+                      throw 'Value is incorrect for DPT 3 (type of value should be Buffer or Value = 0..15 or Object with fields "value.c" = 0..1 and "value.amount" = 0..7)';
                     }
                     break;
                 case '9': //Floating point

--- a/knx.js
+++ b/knx.js
@@ -181,6 +181,19 @@ module.exports = function (RED) {
                 case '1': //Switch
                     value = (value.toString() === 'true' || value.toString() === '1')
                     break;
+                case '3': // Dimmer, control bit + 3 bit value
+                    if (!(value.step && typeof(value.step) == 'boolean')) {
+                      throw 'Value step type needs to be boolean or 0/1';
+                    } else if (value.amount <= 7) {
+                      value = ((value.step.toString() === 'true' || value.step.toString() === '1') << 4) |
+                        parseInt(value.amount) & 7;
+                      buf = new Buffer(1);
+                      buf[0] = value & 8;
+                      value = buf;
+                    } else {
+                      throw 'Value step amount too big for DPT 3';
+                    }
+                    break;
                 case '9': //Floating point
                     value = parseFloat(value);
                     buf = new Buffer(4);

--- a/knx.js
+++ b/knx.js
@@ -182,13 +182,13 @@ module.exports = function (RED) {
                     value = (value.toString() === 'true' || value.toString() === '1')
                     break;
                 case '3': // Dimmer, control bit + 3 bit value
-                    if (!(value.c)) {
+                    if (typeof(value.c)==='undefined') {
                       throw 'Value up/down control missing';
                     } else if (value.amount <= 7) {
-                      value = ((value.c.toString() === 'true' || value.c.toString() === '1') << 4) |
+                      value = ((value.c.toString() === 'true' || value.c.toString() === '1') << 3) |
                         parseInt(value.amount) & 7;
                       buf = new Buffer(1);
-                      buf[0] = value & 8;
+                      buf[0] = value & 15;
                       value = buf;
                     } else {
                       throw 'Value step amount too big for DPT 3';

--- a/knx.js
+++ b/knx.js
@@ -182,8 +182,8 @@ module.exports = function (RED) {
                     value = (value.toString() === 'true' || value.toString() === '1')
                     break;
                 case '3': // Dimmer, control bit + 3 bit value
-                    if (!(value.step && typeof(value.step) == 'boolean')) {
-                      throw 'Value step type needs to be boolean or 0/1';
+                    if (!(value.step)) {
+                      throw 'Value step missing';
                     } else if (value.amount <= 7) {
                       value = ((value.step.toString() === 'true' || value.step.toString() === '1') << 4) |
                         parseInt(value.amount) & 7;

--- a/knx.js
+++ b/knx.js
@@ -182,10 +182,10 @@ module.exports = function (RED) {
                     value = (value.toString() === 'true' || value.toString() === '1')
                     break;
                 case '3': // Dimmer, control bit + 3 bit value
-                    if (!(value.step)) {
-                      throw 'Value step missing';
+                    if (!(value.c)) {
+                      throw 'Value up/down control missing';
                     } else if (value.amount <= 7) {
-                      value = ((value.step.toString() === 'true' || value.step.toString() === '1') << 4) |
+                      value = ((value.c.toString() === 'true' || value.c.toString() === '1') << 4) |
                         parseInt(value.amount) & 7;
                       buf = new Buffer(1);
                       buf[0] = value & 8;


### PR DESCRIPTION
I've done some work towards support for DPT3. I have done some local testing just running the code without any knx equipment while I wait on some to be returned to me with a DPT3 dimmer added. However, before I get to test on hardware, I thought I would submit a preliminary pull request so you can see the direction I've gone down and review that, before changes, testing, and then merge & close. Notably I've broken down the value into a control bit "c" (true/1 for up, false/0 for down) and then the 3 bit amount.
Some sample json payload you can inject:
```json
{"dstgad":"5/0/2","dpt":"3","value":{"c":"true","amount":"5"}}
```
