### PR TITLE
Add option to reduce logs

### DIFF
--- a/knx.html
+++ b/knx.html
@@ -51,9 +51,13 @@
         <label for="node-input-name"><i class="icon-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
-    	<div class="form-row">
+    <div class="form-row">
         <label for="node-input-controller"><i class="icon-bookmark"></i> Controller</label>
         <input type="text" id="node-input-controller">
+    </div>
+    <div class="form-row">
+        <input type="checkbox" id="node-input-debug" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-debug" style="width: auto"> Debug logs</label>
     </div>
 
 
@@ -67,6 +71,10 @@
    	<div class="form-row">
         <label for="node-input-controller"><i class="icon-bookmark"></i> Controller</label>
         <input type="text" id="node-input-controller">
+    </div>
+    <div class="form-row">
+        <input type="checkbox" id="node-input-debug" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-debug" style="width: auto"> Debug logs</label>
     </div>
 </script>
 
@@ -151,7 +159,8 @@
         color: '#ffffff',
         defaults: {
             name: {value: ""},
-            controller: {value: "", type: "knx-controller"}
+            controller: {value: "", type: "knx-controller"},
+            debug: {value: false}
         },
         inputs: 1,
         outputs: 0,
@@ -169,7 +178,8 @@
         color: '#ffffff',
         defaults: {
             name: {value: ""},
-            controller: {value: "", type: "knx-controller"}
+            controller: {value: "", type: "knx-controller"},
+            debug: {value: false}
         },
         inputs: 0,
         outputs: 1,

--- a/knx.js
+++ b/knx.js
@@ -71,11 +71,14 @@ module.exports = function (RED) {
     function KnxOut(config) {
         RED.nodes.createNode(this, config);
         this.name = config.name;
+        this.debug = config.debug;
         this.ctrl = RED.nodes.getNode(config.controller);
         var node = this;
         //node.log('new Knx-OUT, config: ' + util.inspect(config));
         this.on("input", function (msg) {
-            node.log('knxout.onInput, msg[' + util.inspect(msg) + ']');
+            if (node.debug) {
+                node.log('knxout.onInput, msg[' + util.inspect(msg) + ']');
+            }
             if (!(msg && msg.hasOwnProperty('payload'))) return;
             var payload;
             if (typeof(msg.payload) === "object") {
@@ -175,7 +178,9 @@ module.exports = function (RED) {
             dpt = dpt ? dpt.toString(): '1';
             if (action !== 'write' && action!== 'read')
                 throw 'Unsupported action[' + action + '] inside of groupAddrSend';
-            node.log('groupAddrSend action[' + action + '] dstgad:' + dstgad + ', value:' + value + ', dpt:' + dpt);
+            if (node.debug) {
+                node.log('groupAddrSend action[' + action + '] dstgad:' + dstgad + ', value:' + value + ', dpt:' + dpt);
+            }
             if (action === 'write') {
             	switch (dpt) {
                 case '1': //Switch
@@ -404,7 +409,9 @@ module.exports = function (RED) {
                     connection.on('disconnected', nodeStatusDisconnected);
 
                     try {
-                        node.log("sendAPDU: " + util.inspect(value));
+                        if (node.debug) {
+                            node.log("sendAPDU: " + util.inspect(value));
+                        }
                         if (action === 'read')
                         	connection.RequestStatus(dstgad.toString());
                         else if (action === 'write')
@@ -431,6 +438,7 @@ module.exports = function (RED) {
     function KnxIn(config) {
         RED.nodes.createNode(this, config);
         this.name = config.name;
+        this.debug = config.debug;
         this.connection = null;
         var node = this;
         //node.log('new KNX-IN, config: ' + util.inspect(config));
@@ -462,7 +470,9 @@ module.exports = function (RED) {
         }
 
         node.receiveEvent = function (gad, data, datagram) {
-            node.log('knx event gad[' + gad + ']data[' + data.toString('hex') + ']');
+            if (node.debug) {
+                node.log('knx event gad[' + gad + ']data[' + data.toString('hex') + ']');
+            }
             node.send({
                 topic: 'knx:event',
                 payload: {
@@ -477,7 +487,9 @@ module.exports = function (RED) {
             });
         };
         node.receiveStatus = function (gad, data, datagram) {
-            node.log('knx status gad[' + gad + ']data[' + data.toString('hex') + ']');
+            if (node.debug) {
+                node.log('knx status gad[' + gad + ']data[' + data.toString('hex') + ']');
+            }
             node.send({
                 topic: 'knx:status',
                 payload: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-knx",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "KNX for node-red, utilizing pure JavaScript KNXnet/IP driver (both works: tunelling & routing)",
   "main": "knx.js",
   "scripts": {


### PR DESCRIPTION
Close estbeetoo/node-red-contrib-knx#33

As I proposed in the feature request, here is a pull request which adds a checkbox on both `knx-in` and `knx-out` nodes allowing user to get all standard events related logs (deactivated by default).

Let me know if you are ok with it and if you can publish this 0.11.0 version to npm 😉